### PR TITLE
added GDRP function

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -6,7 +6,7 @@
     </list>
   </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="Android Studio default JDK" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="Android Studio default JDK" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/adsdk/src/main/java/com/appyhigh/adsdk/AdSdk.kt
+++ b/adsdk/src/main/java/com/appyhigh/adsdk/AdSdk.kt
@@ -19,6 +19,7 @@ import com.google.android.gms.ads.MobileAds
 import com.google.android.gms.ads.RequestConfiguration
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
+import com.google.android.ump.ConsentDebugSettings
 import com.google.android.ump.ConsentInformation
 import com.google.android.ump.ConsentRequestParameters
 import com.google.android.ump.UserMessagingPlatform
@@ -32,15 +33,22 @@ object AdSdk {
 
     fun getConsentForEU(
         activity: Activity,
+        testDeviceHashedId: String? = null,
         consentRequestListener: ConsentRequestListener
     ) {
         try {
-            //Debugging
-//            val debugSettings = ConsentDebugSettings.Builder(activity)
-//                .setDebugGeography(ConsentDebugSettings.DebugGeography.DEBUG_GEOGRAPHY_EEA)
-//                .addTestDeviceHashedId("1EA55AD5EAAA03034C15481D2B68CBED")
-//                .build()
-            val params = ConsentRequestParameters.Builder()
+            val params = testDeviceHashedId?.let {
+                val debugSettings = ConsentDebugSettings.Builder(activity)
+                    .setDebugGeography(ConsentDebugSettings.DebugGeography.DEBUG_GEOGRAPHY_EEA)
+                    .addTestDeviceHashedId(it)
+                    .build()
+
+                ConsentRequestParameters.Builder()
+                    .setTagForUnderAgeOfConsent(false)
+                    .setConsentDebugSettings(debugSettings)
+                    .build()
+
+            } ?: ConsentRequestParameters.Builder()
                 .setTagForUnderAgeOfConsent(false)
                 .build()
 

--- a/adsdk/src/main/java/com/appyhigh/adsdk/interfaces/ConsentRequestListener.kt
+++ b/adsdk/src/main/java/com/appyhigh/adsdk/interfaces/ConsentRequestListener.kt
@@ -1,0 +1,6 @@
+package com.appyhigh.adsdk.interfaces
+
+interface ConsentRequestListener {
+    fun onError(message: String, code: Int)
+    fun onSuccess()
+}

--- a/adsdk/src/main/res/values/strings.xml
+++ b/adsdk/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
     <string name="app_name">adsdk</string>
     <string name="error_no_play_services">No Google Play Services Found on Device!</string>
     <string name="error_reading_file">Unable to read ad_utils_response.json file.</string>
+    <string name="consent_exception">Not able to get the consent from user</string>
     <string name="exception_reading_file">Exception reading ad_utils_response.json file.</string>
     <string name="sdk_successful">AdSdk Initialized Successfully</string>
     <string name="text_ad">Ad</string>

--- a/app/src/main/java/com/appyhigh/adsdk/MainActivity.kt
+++ b/app/src/main/java/com/appyhigh/adsdk/MainActivity.kt
@@ -8,7 +8,6 @@ import com.appyhigh.adsdk.data.enums.UpdateType
 import com.appyhigh.adsdk.data.model.AdSdkError
 import com.appyhigh.adsdk.interfaces.*
 import com.appyhigh.adsdk.utils.Logger
-import com.google.firebase.FirebaseApp
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.perf.ktx.performance
 import com.google.firebase.perf.metrics.Trace
@@ -22,6 +21,17 @@ class MainActivity : AppCompatActivity() {
         var mTraceFailure: Trace? = Firebase.performance.newTrace("initialize_ads_sdk_failure")
         mTraceSuccess?.start()
         mTraceFailure?.start()
+        AdSdk.getConsentForEU(this,object : ConsentRequestListener{
+            override fun onError(message: String, code: Int) {
+                //Give the user a prompt or call initialize anyway
+            }
+
+            override fun onSuccess() {
+                //Call initialize method now
+                // For NON-EU countries / when a consent form is not available(i.e. if the user has already accepted the consent) this is called
+            }
+
+        })
         AdSdk.initialize(
             application = application,
             testDevice = null,
@@ -209,6 +219,6 @@ class MainActivity : AppCompatActivity() {
 //                        }
 //                    }
 //                )
-        }, 5000)
+        }, 10000)
     }
 }


### PR DESCRIPTION
### Handle Consent for EU Countries [(Ref)](https://developers.google.com/admob/android/privacy)

Call getConsentForEU method to automatically handle the consent and forms inside the current activity. This method provides a callback with success and failure listener, handle them in your app.

For NON-EU countries / when a consent form is not available(i.e. if the user has already accepted the consent) onSuccess() method is automatically called.

_Debugging : Pass your test device hashed id, after getting it from logcat first (filter: UserMessagingPlatform)_ 

```
AdSdk.getConsentForEU( YOUR ACTIVITY , YOUR TEST DEVICE HASHED ID string, object : ConsentRequestListener{
            override fun onError(message: String, code: Int) {
               //Give the user a prompt or call initialize anyway
            }

            override fun onSuccess() {
                //Call initialize method now for AdSdk
            }
        })
```